### PR TITLE
fix(kubernetes-secrets): skip to read directory from secrets location

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 var config = require('config');
 var Path = require('path');
 var jetpack = require('fs-jetpack');
+var fs = require('fs');
 
 getSecrets = function() {
   var secretsPath = process.env.SECRET_PATH || '/run/secrets'
 
   var result = {};
-  var files = jetpack.list(secretsPath);
+  var all = jetpack.list(secretsPath);
+  var files = all.filter(file => !fs.statSync(`${secretsPath}/${file}`).isDirectory());
   if (files) {
     for (var i = 0; i < files.length; i++) {
       var file = files[i];


### PR DESCRIPTION
Kubernetes allow to mount secrets in given directory for example `/etc/secrets`. It actually creates dynamic directory for example `..2019_02_01_06_05_14.163205431` and then creates symbolic directory `..data` which maps to `..2019_02_01_06_05_14.163205431`. Then it creates symbolic link for each key inside `/etc/secrets` directory to `/etc/secrets/..data`.

Currently, `jetpack.read(`${secretsPath}/${file}`, 'utf8')` fails to read directory `..2019_02_01_06_05_14.163205431`. Since reading directory is no use therefore we can simply skip directory. 

This will help to use `config-secrets` module for kubernetes secrets as well.